### PR TITLE
WIP: 94 Use ref prop on withReveal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 dist
 node_modules
 npm-debug.log
-.npmrc
 /RevealBase.js
 /makeCarousel.js
 /swipedetect.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dist
 node_modules
 npm-debug.log
+.npmrc
 /RevealBase.js
 /makeCarousel.js
 /swipedetect.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+//npm.pkg.github.com/:_authToken=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
+@canadainnovates:registry=https://npm.pkg.github.com

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <h2>Disclaimer:</h2>
-<p>This is a fork of rnosov/react-reveal with fixes for warnings in React <code>^18.x.x</code></p>
+<p>This is a fork of @successtar/react-reveal with fixes for ref injection with withReveal HOC with React=<code>^18.x.x</code></p>
 # React Reveal
 
-[React Reveal](https://www.react-reveal.com/) is
-an animation framework for React. It's MIT licensed, has a tiny footprint
-and written specifically for React in ES6. It can be used to create various cool reveal
-on scroll animations in your application.
+[React Reveal by CanadaInnovates](https://github.com/CanadaInnovates/react-reveal) is an extension of [React Reveal](https://www.react-reveal.com/),
+an animation framework for React. Along with the various
+cool reveal on scroll animations, we're aimed at migrating react-reveal
+to expose hooks API for the latest cool features of React in Functional components.
 If you liked this package, don't forget to star
-the [Github repository](https://github.com/successtar/react-reveal).
+the [Github repository](https://github.com/CanadaInnovates/react-reveal).
 
 ## Live Examples
 
@@ -31,21 +31,21 @@ For a full documentation please visit [online docs](https://www.react-reveal.com
 In the command prompt run:
 
 ```sh
-npm install @successtar/react-reveal --save
+npm install @canadainnovates/react-reveal --save
 ```
 
 Alternatively you may use `yarn`:
 
 ```sh
-yarn add @successtar/react-reveal
+yarn add @canadainnovates/react-reveal
 ```
 
 ## Quick Start
 
-Import effects from [React Reveal](https://www.npmjs.com/package/@successtar/react-reveal) to your project. Lets try `Zoom` effect first:
+Import effects from [React Reveal](https://www.npmjs.com/package/@canadainnovates/react-reveal) to your project. Lets try `Zoom` effect first:
 
 ```javascript
-import Zoom from '@successtar/react-reveal/Zoom';
+import Zoom from '@canadainnovates/react-reveal/Zoom';
 ```
 
 Place the following code somewhere in your `render` method: 
@@ -90,7 +90,7 @@ or if you want to customize `div` props:
 
 ## Revealing Images
 
-If you want to reveal an image you can wrap `img` tag with with the desired `@successtar/react-reveal` effect:
+If you want to reveal an image you can wrap `img` tag with with the desired `@canadainnovates/react-reveal` effect:
 
 ```jsx
 <Zoom>
@@ -102,7 +102,7 @@ It would be a very good idea to specify width and height of any image you wish t
 
 ## Children
 
-`@successtar/react-reveal` will attach a reveal effect to each child it gets. In other words,
+`@canadainnovates/react-reveal` will attach a reveal effect to each child it gets. In other words,
 
 ```jsx
 <Zoom>
@@ -136,11 +136,11 @@ If you don't want this to happen, you should wrap multiple children in a `div` t
 
 ## Server Side Rendering
 
-`@successtar/react-reveal` supports server side rendering out of the box. In some cases, when the javascript bundle arrives much later than the HTML&CSS it might cause a flickering. To prevent this `@successtar/react-reveal` will not apply reveal effects on the initial load. 
-Another option is to apply gentle fadeout effect on the initial render. You can force it on all `@successtar/react-reveal` elements by placing the following code somewhere near the entry point of your app:
+`@canadainnovates/react-reveal` supports server side rendering out of the box. In some cases, when the javascript bundle arrives much later than the HTML&CSS it might cause a flickering. To prevent this `@canadainnovates/react-reveal` will not apply reveal effects on the initial load. 
+Another option is to apply gentle fadeout effect on the initial render. You can force it on all `@canadainnovates/react-reveal` elements by placing the following code somewhere near the entry point of your app:
 
 ```jsx
-import config from '@successtar/react-reveal/globals';
+import config from '@canadainnovates/react-reveal/globals';
 
 config({ ssrFadeout: true });
 ```
@@ -153,37 +153,43 @@ Or you you can do it on a per element basis using `ssrFadeout` prop:
 
 One last option is to use `ssrReveal` prop. If enabled, this option will suppress both flickering and `ssrFadeout` effect. The unfortunate drawback of this option is that the revealed content will appear hidden to Googlebot and to anyone with javascript switched off. So it will makes sense for images and/or headings which are duplicated elsewhere on the page.
 
-## Forking This Package
+## Ref Injection with withReveal
 
-Clone the this repository using the following command:
+withReveal will wrap your component in a div tag for it to work. If you don't want that then you can pass `forwardRef` prop to the component created with withReveal.Consider following custom React Component:
 
-```sh
-git clone https://github.com/successtar/react-reveal.git
+```jsx
+const StyledDiv = styled.li`
+  color: palevioletred;
+  font-weight: bold;
+`;
+
+function OldComponent({ innerRef, className, style }) {
+const { innerRef, children, style, ...rest } = props;
+  return (<StyledDiv ref={innerRef} style={style} {...rest}>{children}</StyledDiv>);
+  }
 ```
-
-In the cloned directory, you can run following commands:
-
-```sh
-yarn install
+And then you can inject reveal functionality using following code:
+```jsx
+const NewComponent = withReveal(OldComponent, <Fade left />);
 ```
-
-yInstalls required node modules
-
-```sh
-yarn build
+And then you can pass `forwardRef` prop to the NewComponent where you use it in the code like this:
+```jsx
+<NewComponent forwardRef>Some content of 1</NewComponent>
 ```
+## Up-coming Features
+In the pipeline, we are going the add functional hooks for all available
+reveal effects. Here is a list of hooks for simple effects:
 
-Builds the package for production to the `dist` folder
-
-```sh
-yarn test
-```
-
-Runs tests
+Fade -> useFade
+Flip -> useFlip
+Rotate -> Rotate
+Zoom -> useZoom
+Bounce -> useBounce
+Roll -> useRoll
 
 ## License
 
-Copyright © 2022 Hammed Olalekan Osanyinpeju.
+Copyright © 2022 CanadaInnovates.
 
 Credit: Roman Nosov 2018.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 <h2>Disclaimer:</h2>
 <p>This is a fork of @successtar/react-reveal with fixes for ref injection with withReveal HOC with React=<code>^18.x.x</code></p>
-# React Reveal
+
+## React Reveal
 
 [React Reveal by CanadaInnovates](https://github.com/CanadaInnovates/react-reveal) is an extension of [React Reveal](https://www.react-reveal.com/),
 an animation framework for React. Along with the various

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@canadainnovates/react-reveal",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "owner": "Mustefa <http://mustefa.com>",
   "description": "Really simple way to add reveal on scroll animation to your React app.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@successtar/react-reveal",
-  "version": "1.2.10",
-  "author": "Roman Nosov <rnosov@gmail.com>",
+  "name": "@canadainnovates/react-reveal",
+  "version": "1.0.0",
+  "owner": "Mustefa <http://mustefa.com>",
   "description": "Really simple way to add reveal on scroll animation to your React app.",
   "license": "MIT",
   "keywords": [
@@ -12,10 +12,10 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/successtar/react-reveal"
+    "url": "https://github.com/CanadaInnovates/react-reveal"
   },
   "bugs": {
-    "url": "https://github.com/successtar/react-reveal/issues"
+    "url": "https://github.com/CanadaInnovates/react-reveal/issues"
   },
   "homepage": "https://www.react-reveal.com",
   "main": "./index.js",

--- a/src/lib/withReveal.js
+++ b/src/lib/withReveal.js
@@ -10,10 +10,7 @@
 import React from 'react';
 
 function withReveal(WrappedComponent, effect) {
-  let refProp = undefined;
-  if (typeof WrappedComponent === 'function' && typeof WrappedComponent.styledComponentId === 'string')
-    refProp = "innerRef";
-  return function({
+  return function ({
     force,
     mountOnEnter,
     unmountOnExit,
@@ -32,6 +29,11 @@ function withReveal(WrappedComponent, effect) {
     //disableObserver,
     ...props
   }) {
+    let refProp = undefined;
+    const { forwardRef, ...rest } = props;
+    if (forwardRef) {
+      refProp = "innerRef";
+    }
     return (
       <effect.type
         force={force}
@@ -53,7 +55,7 @@ function withReveal(WrappedComponent, effect) {
         {...effect.props}
         refProp={refProp}
       >
-        <WrappedComponent {...props} />
+        <WrappedComponent {...rest} />
       </effect.type>
     );
   }


### PR DESCRIPTION
## **What?**

This PR has the following changes:

1. Updated react-reveal docs as per current changes and future goals.
2. Published react-reveal to [github packages](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry) with the org-scope as @canadainnovates/react-reveal.
3. Right now published package don't have updated docs as `npm publish` checkout from the master branch.

## **Why?**

To have more control over react-reveal and make changes as per requirements in the future. 

## **How?**

## **Testing?**

## **Future Directions**

Right now ref injection is not working for nested styled-components. Need to make it work for that. Additionally, will add functional hooks for all available reveal effects. Here is a list of hooks for simple effects:

Fade -> useFade
Flip -> useFlip
Rotate -> Rotate
Zoom -> useZoom
Bounce -> useBounce
Roll -> useRoll


## **Screenshots or gifs**
 
![image](https://user-images.githubusercontent.com/70839328/189161507-41dafdc3-eb05-4685-92f1-794c5e962e58.png)

